### PR TITLE
Correctly handle  MPIPoolException arguments

### DIFF
--- a/mpipool/core.py
+++ b/mpipool/core.py
@@ -267,4 +267,5 @@ def _error_function(task):
 
 class MPIPoolException(Exception):
     def __init__(self, tb):
+        super(MPIPoolException, self).__init__(tb)
         self.traceback = tb


### PR DESCRIPTION
Passing non-optional arguments to the Exception baseclass class
to avoid error messages as:
Python: TypeError: **init**() takes exactly...
